### PR TITLE
Soak up nulls in RequestAnimationFrame.coffee

### DIFF
--- a/components/RequestAnimationFrame.coffee
+++ b/components/RequestAnimationFrame.coffee
@@ -1,11 +1,11 @@
 noflo = require 'noflo'
 
 requestAnimationFrame =
-  window.requestAnimationFrame       ||
-  window.webkitRequestAnimationFrame ||
-  window.mozRequestAnimationFrame    ||
-  window.oRequestAnimationFrame      ||
-  window.msRequestAnimationFrame     ||
+  window?.requestAnimationFrame       ||
+  window?.webkitRequestAnimationFrame ||
+  window?.mozRequestAnimationFrame    ||
+  window?.oRequestAnimationFrame      ||
+  window?.msRequestAnimationFrame     ||
   (callback, element) ->
     window.setTimeout( ->
       callback(+new Date())


### PR DESCRIPTION
Components are evaluated when commands such as `noflo list .` are used. `window` doesn't exist at this time, so the entire process fails. It's probably advisable to `try/catch` as each module is evaluated for display.

Anyhow, this works around the problem sufficiently well.
