### PR TITLE
Add preventDefault before event listener on Listen component

### DIFF
--- a/components/Listen.coffee
+++ b/components/Listen.coffee
@@ -40,6 +40,7 @@ class Listen extends noflo.Component
     element.addEventListener type, @change
 
   change: (event) =>
+    event.preventDefault()
     if @outPorts.element.isAttached()
       @outPorts.element.send @element
     if @outPorts.event.isAttached()

--- a/components/Listen.coffee
+++ b/components/Listen.coffee
@@ -7,10 +7,12 @@ class Listen extends noflo.Component
   constructor: ->
     @element = null
     @type = null
+    @preventDefault = false
 
     @inPorts =
       element: new noflo.Port 'object'
       type: new noflo.Port 'string'
+      preventdefault: new noflo.Port 'boolean'
     @outPorts =
       element: new noflo.Port 'object'
       event: new noflo.Port 'object'
@@ -33,6 +35,9 @@ class Listen extends noflo.Component
       if @element
         @subscribe @element, @type
 
+    @inPorts.preventdefault.on 'data', (data) =>
+      @preventDefault = data
+
   unsubscribe: (element, type) ->
     element.removeEventListener type, @change
 
@@ -40,7 +45,8 @@ class Listen extends noflo.Component
     element.addEventListener type, @change
 
   change: (event) =>
-    event.preventDefault()
+    if @preventDefault
+      event.preventDefault()
     if @outPorts.element.isAttached()
       @outPorts.element.send @element
     if @outPorts.event.isAttached()

--- a/components/RemoveElement.coffee
+++ b/components/RemoveElement.coffee
@@ -5,7 +5,7 @@ class RemoveElement extends noflo.Component
   constructor: ->
     @inPorts =
       element: new noflo.Port 'object'
-    @inPorts.element.on 'data', (element) =>
+    @inPorts.element.on 'data', (element) ->
       return unless element.parentNode
       element.parentNode.removeChild element
 


### PR DESCRIPTION
In this [use case](http://jsbin.com/bemuwo/1/edit?js,output) the `preventDefault` is needed to stop event propagation. I guess it will be needed for any events, right?